### PR TITLE
Feat: crear aplicación Express para buscar artistas, álbumes y tracks en Spotify

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,6 +5,8 @@ const hbs = require('hbs');
 
 // require spotify-web-api-node package here:
 
+const SpotifyWebApi = require('spotify-web-api-node');
+
 const app = express();
 
 app.set('view engine', 'hbs');
@@ -13,6 +15,59 @@ app.use(express.static(__dirname + '/public'));
 
 // setting the spotify-api goes here:
 
+const spotifyApi = new SpotifyWebApi({
+  clientId: process.env.CLIENT_ID,
+  clientSecret: process.env.CLIENT_SECRET
+});
+
+//extraer token de acceso
+spotifyApi
+  .clientCredentialsGrant()
+  .then(data => spotifyApi.setAccessToken(data.body['access_token']))
+  .catch(error => console.log('Something went wrong when retrieving an access token', error));
+
+//middleware
+
+
 // Our routes go here:
+
+app.get('/', (req, res) => 
+    res.render('index', {title: 'Spotify lab'})
+)
+
+app.get('/artist-search', (req, res) => {
+    const { artist } = req.query;
+
+    spotifyApi
+        .searchArtists(artist)
+        .then(data => {
+            console.log('The received data from the API: ', data.body);
+            res.render('artist-search-results', { artists: data.body.artists.items })
+        })
+        .catch(err => console.log('The error while searching artists occurred: ', err));
+})
+
+app.get('/albums/:artistId', (req, res) => {
+  const { artistId } = req.params;
+  spotifyApi
+    .getArtistAlbums(artistId)
+    .then(data => {
+      res.render('album', { albums: data.body.items }); //  busca views/album.hbs
+    })
+    .catch(err => console.log(err));
+});
+
+app.get('/view-tracks/:albumId', (req, res) => {
+  const { albumId } = req.params
+  spotifyApi
+    .getAlbumTracks(albumId, { limit: 20, market: 'ES'})
+    .then(data => {
+      console.log(data.body)
+      res.render('view-tracks', {tracks: data.body.items})})
+    .then(err => console.log('Algo fue mal', err))
+})
+
+
+
 
 app.listen(3000, () => console.log('My Spotify project running on port 3000 🎧 🥁 🎸 🔊'));

--- a/package.json
+++ b/package.json
@@ -11,6 +11,12 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "nodemon": "^2.0.2"
+    "nodemon": "^3.1.10"
+  },
+  "dependencies": {
+    "dotenv": "^17.2.2",
+    "express": "^5.1.0",
+    "hbs": "^4.2.0",
+    "spotify-web-api-node": "^5.0.2"
   }
 }

--- a/views/album.hbs
+++ b/views/album.hbs
@@ -1,0 +1,8 @@
+<h2>Albumes </h2>
+
+{{#each albums}}
+    <p>{{this.name}}</p>
+    <img src="{{this.images.[0].url}}" alt="{{this.name}}" width:"150">
+    <a href="/view-tracks/{{this.id}}">Ver Tracks</a>
+    
+{{/each}}

--- a/views/artist-search-results.hbs
+++ b/views/artist-search-results.hbs
@@ -1,0 +1,16 @@
+<h1>Resultados de la busqueda sencillo</h1>
+
+{{#each artists}}
+    <div>
+        <h2>{{this.name}}</h2>
+        <img src="{{this.images.0.url}}" alt="{{this.name}}" width="150">
+        <a href="/albums/{{this.id}}">Ver álbumes</a>
+    </div>
+{{/each}}
+
+
+
+
+
+
+

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -1,0 +1,7 @@
+
+<h1>Buscar artistas</h1>
+<form action="/artist-search" method="GET">
+    <label for="artist">Artist name:</label>
+    <input type="text" id="artist" name="artist">
+    <button type="submit">Search for an artist</button>
+</form>

--- a/views/layout.hbs
+++ b/views/layout.hbs
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{{title}}</title>
+
+  {{!-- Si tienes CSS en /public --}}
+  <link rel="stylesheet" href="/stylesheets/style.css" />
+</head>
+<body>
+  {{!-- Aquí se inyecta la vista (index.hbs, artist-search.hbs, etc.) --}}
+  {{{body}}}
+</body>
+</html>

--- a/views/view-tracks.hbs
+++ b/views/view-tracks.hbs
@@ -1,0 +1,10 @@
+<h2>Tracks</h2>
+
+{{#each tracks}}
+<ul>
+    <li>{{this.name}}</li>
+    <li><audio src="{{this.preview_url}}" type="audio/mpeg" controls></audio></li>
+</ul>
+{{/each}}
+    
+    


### PR DESCRIPTION
# Descripción
Aplicación construida con **Express** y conectada a la API de Spotify, que permite buscar artistas, mostrar sus álbumes y listar los tracks de un álbum. En la vista de tracks se incluye un reproductor con el *preview* de cada canción.

# Cambios realizados
- Configuración de entorno con **dotenv** y creación del archivo `.env` para ocultar las claves de la API de Spotify.  
- Configuración de la aplicación Express:
  - Motor de plantillas **Handlebars (hbs)**.  
  - Carpeta de vistas (`/views`) y carpeta de archivos estáticos (`/public`).  
- Creación de la estructura de carpetas y archivos:  
  - Vistas: `layout.hbs`, `index.hbs`, `artist-search-results.hbs`, `albums.hbs`, `tracks.hbs`.  
- Integración del cliente **spotify-web-api-node** siguiendo la guía oficial de npm.  
- Implementación de rutas con peticiones **GET** en Express:  
  - `/` → página principal con formulario de búsqueda de artista.  
  - `/artist-search` → muestra los resultados de búsqueda de artistas.  
  - `/albums/:artistId` → lista de álbumes del artista seleccionado.  
  - `/tracks/:albumId` → lista de canciones de un álbum, con preview de audio si está disponible.  
- Consulta y análisis de las respuestas de la API de Spotify (`data.body`) para mapear la información en las vistas dinámicas con Handlebars.  
- Apertura del puerto con `app.listen`.  

# Comprobación
- Ejecución del servidor con **nodemon app.js**.  
- Verificación en navegador:  
  - `/` → formulario de búsqueda de artista.  
  - `/artist-search` → listado de artistas devuelto por la API.  
  - `/albums/:artistId` → listado de álbumes del artista seleccionado.  
  - `/tracks/:albumId` → listado de canciones con reproductor de preview.  
- Revisión de que los archivos estáticos (CSS/JS) se sirven correctamente desde `/public`.  
- Comprobación de que la navegación entre vistas es correcta y el renderizado dinámico funciona en todas

